### PR TITLE
Fix file argument for sbfile command

### DIFF
--- a/mboot/__main__.py
+++ b/mboot/__main__.py
@@ -383,7 +383,7 @@ def mconf(ctx, address, word, mtype, file):
 
 # McuBoot: receive SB file command
 @cli.command(short_help="Receive SB file")
-@click.argument('file', nargs=1, type=ImgFile(('.bin', '.sb', '.sb2'), True))
+@click.argument('file', nargs=1, type=ImgFile('.bin', '.sb', '.sb2', exists=True))
 @click.pass_context
 def sbfile(ctx, file):
 


### PR DESCRIPTION
The file argument for the sbfile command used an invalid ImgFile value,
leading to error messages when trying to invoke the command.  This patch
fixes the ImgFile.